### PR TITLE
fix: don't let get return null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ class RedisStore {
   }
 
   async get (key: string): Promise<string | undefined> {
-    return this._redis.get(key) || undefined
+    return (await this._redis.get(key)) || undefined
   }
 
   async put (key: string, value: string): Promise<undefined> {


### PR DESCRIPTION
`get` was returning `null` instead of `undefined` resulting in this error when the `null` object was found in the cache:
https://github.com/interledgerjs/ilp-plugin-xrp-asym-server/blob/9790aafb7a2d4c63ada93e8a5c331345afc692ab/src/store-wrapper.ts#L36-L37